### PR TITLE
bundle if there is a gemfile after bumping so next bundle does not generate a diff

### DIFF
--- a/bin/bump
+++ b/bin/bump
@@ -2,7 +2,8 @@
 require 'optparse'
 
 options = {
-  :commit => true
+  :commit => true,
+  :bundle => File.exist?("Gemfile")
 }
 OptionParser.new do |opts|
   opts.banner = <<BANNER
@@ -17,6 +18,7 @@ Usage:
 Options:
 BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
+  opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("-h", "--help","Show this.") { puts opts; exit }
 end.parse!
 

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -36,13 +36,15 @@ module Bump
       current, file = current_version
       next_version = next_version(current, part)
       replace(file, current, next_version)
-      commit(next_version, file) if options[:commit]
+      system("bundle") if options[:bundle]
+      commit(next_version, file, options) if options[:commit]
       ["Bump version #{current} to #{next_version}", 0]
     end
 
-    def self.commit(version, file)
+    def self.commit(version, file, options)
       return unless File.directory?(".git")
-      raise unless system("git add #{file} && git commit -m 'v#{version}'")
+      system("git add --update Gemfile.lock") if options[:bundle]
+      system("git add --update #{file} && git commit -m 'v#{version}'")
     end
 
     def self.replace(file, old, new)


### PR DESCRIPTION
- `--no-bundle` optout
- does not add Gemfile.lock when it is not tracked / ignored
- prevents that e.g. currently on bump master a bundle changes the Gemfile.lock :)
