### PR TITLE
do not bundle if Gemfile.lock is not tracked

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -37,7 +37,7 @@ module Bump
       current, file = current_version
       next_version = next_version(current, part)
       replace(file, current, next_version)
-      system("bundle") if options[:bundle]
+      system("bundle") if options[:bundle] and under_version_control?("Gemfile.lock")
       commit(next_version, file, options) if options[:commit]
       ["Bump version #{current} to #{next_version}", 0]
     end
@@ -114,6 +114,11 @@ module Bump
       end
       version = [major, minor, patch, *other].compact.join('.')
       [version, prerelease].compact.join('-')
+    end
+
+    def self.under_version_control?(file)
+      @all_files ||= `git ls-files`.split(/\r?\n/)
+      @all_files.include?(file)
     end
   end
 end

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -249,12 +249,13 @@ describe Bump do
       Bundler.with_clean_env { bump("patch --no-bundle") }
       read(gemspec).should include "1.0.1"
       read("Gemfile.lock").should include "1.0.0"
+      `git status --porcelain`.should include "?? Gemfile.lock"
     end
 
-    it "does not commit an untracked Gemfile.lock" do
+    it "does not bundle or commit an untracked Gemfile.lock" do
       Bundler.with_clean_env { bump("patch") }
-      read("Gemfile.lock").should include "1.0.1"
-      `git status`.should include "Untracked files:"
+      read("Gemfile.lock").should include "1.0.0"
+      `git status --porcelain`.should include "?? Gemfile.lock"
     end
   end
 


### PR DESCRIPTION
just a little performance improvement, since there is no point in bundling when the Gemfile.lock is not tracked
