### PR TITLE
Use new version format of rubinius in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
   - 2.1.0
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2.1.1
 matrix:
   allow_failures:
     - rvm: 2.1.0


### PR DESCRIPTION
Travis and Rubinius no longer use the rbx-18mode/19mode syntax for .travis.yml. I've updated the travis file to the recommended rbx version in the travis readme.

See http://rubini.us/2013/12/03/testing-with-rbx-on-travis/
