### PR TITLE
Call `bundle update` to update `Gemfile.lock`

### DIFF
--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -311,7 +311,7 @@ describe Bump do
       `git add Gemfile.lock`
       bump("patch")
       read("Gemfile.lock").should include "1.0.1"
-      `git status`.should include "nothing to commit"
+      `git status`.should include "nothing added to commit"
     end
 
     it "does not bundle with --no-bundle" do


### PR DESCRIPTION
This fixes the test failures e.g.
https://travis-ci.org/gregorym/bump/jobs/17940162

While debugging this failure I discovered 2 warnings:
- Gemfile (source)
- generated gemspec (missing author)
