### PR TITLE
allow configuration to enable auto-tagging of the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ If you want to append additional information to the commit message, pass it in u
 ```Ruby
 # Rakefile
 require "bump/tasks"
+
+#
+# if you want to always tag the verison, add:
+# Bump.tag_by_default = true
+#
+
 ```
 
     rake bump:patch

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -5,6 +5,10 @@ module Bump
   class TooManyVersionFilesError < StandardError; end
   class UnfoundVersionFileError < StandardError; end
 
+  class <<self
+    attr_accessor :tag_by_default
+  end
+
   class Bump
     BUMPS         = %w(major minor patch pre)
     PRERELEASE    = ["alpha","beta","rc",nil]
@@ -17,7 +21,7 @@ module Bump
         {
           :commit => true,
           :bundle => File.exist?("Gemfile"),
-          :tag => false
+          :tag => ::Bump.tag_by_default
         }
       end
   

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -15,7 +15,7 @@ namespace :bump do
     end
 
     task bump, :tag do |_task, args|
-      run_bump.call(bump, :tag => args[:tag])
+      run_bump.call(bump, args)
     end
   end
 

--- a/spec/bump/tasks_spec.rb
+++ b/spec/bump/tasks_spec.rb
@@ -5,7 +5,9 @@ describe "rake bump" do
 
   before do
     write "VERSION", "1.2.3\n"
-    write "Rakefile", "require File.expand_path('../../../lib/bump/tasks', __FILE__)"
+    rakefile_require = "require File.expand_path('../../../lib/bump/tasks', __FILE__)"
+    write "Rakefile", rakefile_require
+    write "Rakefile.with_defaults", "#{rakefile_require}\nBump.tag_by_default = true"
     raise unless system("git add VERSION")
   end
 
@@ -18,6 +20,11 @@ describe "rake bump" do
 
   it "bumps a version and can optionally tag it" do
     run "rake bump:patch[true]"
+    `git tag`.split("\n").last.should == "v1.2.4"
+  end
+
+  it "honors the tag setting in Bump::Bump.defaults" do
+    run "rake -f Rakefile.with_defaults bump:patch"
     `git tag`.split("\n").last.should == "v1.2.4"
   end
 


### PR DESCRIPTION
My use case is that for some projects, I always want to tag the release, and I tend to forget to pass `[true]` into the rake task.  So this PR enables me to add:

```
Bump.tag_by_default = true
```

into my Rakefile