### PR TITLE
Bumping with commit message feels like git command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ If you don't want to run the `bundle` command after bumping, add the `--no-bundl
     
     bump patch --no-bundle
 
-### --commit-message [MSG]
-If you want to append additional information to the commit message, pass it in using the `--commit-message [MSG]` option.
+### --commit-message [MSG], -m [MSG]
+If you want to append additional information to the commit message, pass it in using the `--commit-message [MSG]` or `-m [MSG]` option.
 
     bump patch --commit-message [no-ci]
+
+or
+
+    bump patch -m [no-cli]
 
 ### Rake
 

--- a/bin/bump
+++ b/bin/bump
@@ -17,7 +17,7 @@ Usage:
 Options:
 BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
-  opts.on("--commit-message [MSG]", "Append MSG to the commit message.") {|msg| options[:commit_message] = msg }
+  opts.on("-m","--commit-message [MSG]", "Append MSG to the commit message.") {|msg| options[:commit_message] = msg }
   opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("-h", "--help","Show this.") { puts opts; exit }

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -45,6 +45,26 @@ describe Bump do
       `git status`.should include "nothing to commit"
     end
 
+    it "should append commit message if --commit-message flag was given" do
+      write_gemspec
+      `git add #{gemspec}`
+
+      bump("patch --commit-message 'Commit message.'")
+
+      `git log -1 --pretty=format:'%s'`.should include "Commit message."
+      `git status`.should include "nothing to commit"
+    end
+
+    it "should append commit message if -m flag gas given" do
+      write_gemspec
+      `git add #{gemspec}`
+
+      bump("patch -m 'Commit message.'")
+
+      `git log -1 --pretty=format:'%s'`.should include "Commit message."
+      `git status`.should include "nothing to commit"
+    end
+
     it "should not commit if --no-commit flag was given" do
       write_gemspec
       `git add #{gemspec}`


### PR DESCRIPTION
Hello @gregorym 

Could we add optional command for `--commit-message` option?

Most of time, writing long text command `--commit-message` every time I commit is bothering me. It will be more easier if I can do `bump patch -m "My commit message."`

It just feels like git.

Thanks a bunch.