### PR TITLE
Upgrade to latest rake and fix rake's version specifier

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     byebug (8.2.0)
     diff-lcs (1.1.3)
-    rake (10.0.2)
+    rake (11.2.2)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -24,5 +24,8 @@ PLATFORMS
 DEPENDENCIES
   bump!
   byebug
-  rake (~> 10.0.0)
+  rake (~> 11.0)
   rspec (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/bump.gemspec
+++ b/bump.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new "bump" do |s|
   s.license = "MIT"
   s.executables = ["bump"]
 
-  s.add_development_dependency 'rake', '~> 10.0.0'
+  s.add_development_dependency 'rake', '~> 11.0'
   s.add_development_dependency 'rspec', '~> 2.0'
 end
 


### PR DESCRIPTION
The previous rake version spec (~> 10.0.0) prevented minor version
updates. Since it included three digits, the effective range was 10.0.0
<= x < 10.1.0. I'm assuming it was actually intended to be 10.0.0 <= x <
1.0.0.

Also, bump to rake 11.x