### PR TITLE
Upgrade to RSpec 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     byebug (8.2.0)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     rake (11.2.2)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -26,7 +31,7 @@ DEPENDENCIES
   bundler
   byebug
   rake (~> 11.0)
-  rspec (~> 2.0)
+  rspec (~> 3.0)
 
 BUNDLED WITH
    1.11.2

--- a/bump.gemspec
+++ b/bump.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new "bump" do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 11.0'
-  s.add_development_dependency 'rspec', '~> 2.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,8 @@ module SpecHelpers
   end
 end
 
-RSpec.configure do |c|
-  c.include SpecHelpers::InstanceMethods
-  c.extend SpecHelpers::ClassMethods
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.include SpecHelpers::InstanceMethods
+  config.extend SpecHelpers::ClassMethods
 end


### PR DESCRIPTION
Bump rspec to v3 (for features like `fit` and simplified boolean tags, etc).

This PR sets the syntax to `should` explicitly (as is required in rspec3). Would you prefer the test suite just be migrated to `expect`?