### PR TITLE
⚠ shadowing outer local variable - file

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -139,8 +139,8 @@ module Bump
 
       def version_from_lib_rb
         files = Dir.glob("lib/**/*.rb")
-        file = files.detect do |file|
-          File.read(file) =~ /^\s+VERSION = ['"](#{VERSION_REGEX})['"]/i
+        file = files.detect do |f|
+          File.read(f) =~ /^\s+VERSION = ['"](#{VERSION_REGEX})['"]/i
         end
         [$1, file] if file
       end


### PR DESCRIPTION
This patch fixes a Ruby warning.