### PR TITLE
README: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ or
 require "bump/tasks"
 
 #
-# if you want to always tag the verison, add:
+# if you want to always tag the version, add:
 # Bump.tag_by_default = true
 #
 


### PR DESCRIPTION
This PR fixes a tiiiiny typo in the README. 

(I use `bump` and I'm grateful it exists. Thanks!)