### PR TITLE
Fix rake tasks to accept all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ require "bump/tasks"
 
     rake bump:patch
     rake bump:current
+    rake bump:patch[false,true,false]    # passing {tag: false, commit: true, bundle: false} options
+    rake bump:minor[true,true,false]     # passing {tag: true, commit: true, bundle: false} options
 
 ### Ruby
 ```Ruby

--- a/README.md
+++ b/README.md
@@ -61,11 +61,19 @@ require "bump/tasks"
 #
 
 ```
+    
+    rake bump:current                           # display current version
 
+    # bumping using defaults for `COMMIT`, `TAG`, and `BUNDLE`
+    rake bump:major
     rake bump:patch
-    rake bump:current
-    rake bump:patch COMMIT=true TAG=false BUNDLE=false
-    rake bump:minor BUNDLE=false
+    rake bump:minor
+    rake bump:pre
+
+    # bumping with option(s)
+    rake bump:patch TAG=false BUNDLE=false      # commit, but don't tag or run `bundle`
+    rake bump:patch COMMIT=false TAG=false      # don't commit, don't tag
+    rake bump:minor BUNDLE=false                # don't run `bundle`
 
 ### Ruby
 ```Ruby

--- a/README.md
+++ b/README.md
@@ -64,11 +64,8 @@ require "bump/tasks"
 
     rake bump:patch
     rake bump:current
-    rake bump:patch[false,true,false]              # passing {tag: false, commit: true, bundle: false} options
-    rake bump:patch TAG=false BUNDLE=false         # passing {tag: false, bundle: false} options
-    rake bump:minor[true,true,false]               # passing {tag: true, commit: true, bundle: false} options
-    rake bump:minor BUNDLE=false                   # passing {bundle: false} options
-    rake bump:major[true] PATCH=false              # argument option overrides corresponding option from env. variable, passing {tag: true} options
+    rake bump:patch COMMIT=true TAG=false BUNDLE=false
+    rake bump:minor BUNDLE=false
 
 ### Ruby
 ```Ruby

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ require "bump/tasks"
 
     rake bump:patch
     rake bump:current
-    rake bump:patch[false,true,false]    # passing {tag: false, commit: true, bundle: false} options
-    rake bump:minor[true,true,false]     # passing {tag: true, commit: true, bundle: false} options
+    rake bump:patch[false,true,false]              # passing {tag: false, commit: true, bundle: false} options
+    rake bump:patch TAG=false BUNDLE=false         # passing {tag: false, bundle: false} options
+    rake bump:minor[true,true,false]               # passing {tag: true, commit: true, bundle: false} options
+    rake bump:minor BUNDLE=false                   # passing {bundle: false} options
+    rake bump:major[true] PATCH=false              # argument option overrides corresponding option from env. variable, passing {tag: true} options
 
 ### Ruby
 ```Ruby

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -4,6 +4,7 @@ module Bump
   class UnfoundVersionError < StandardError; end
   class TooManyVersionFilesError < StandardError; end
   class UnfoundVersionFileError < StandardError; end
+  class RakeArgumentsDeprecatedError < StandardError; end
 
   class <<self
     attr_accessor :tag_by_default

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -27,7 +27,6 @@ module Bump
       end
 
       def run(bump, options={})
-        parse_cli_options!(options)
         options = defaults.merge(options)
 
         case bump
@@ -57,14 +56,14 @@ module Bump
         current_info.first
       end
 
-      private
-
       def parse_cli_options!(options)
         options.each do |key, value|
           options[key] = parse_cli_options_value(value)
         end
         options.delete_if{|key, value| value.nil?}
       end
+
+      private
 
       def parse_cli_options_value(value)
         case value

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -19,13 +19,14 @@ module Bump
 
       def defaults
         {
+          :tag => ::Bump.tag_by_default,
           :commit => true,
-          :bundle => File.exist?("Gemfile"),
-          :tag => ::Bump.tag_by_default
+          :bundle => File.exist?("Gemfile")
         }
       end
 
       def run(bump, options={})
+        sanitize_options!(options)
         options = defaults.merge(options)
 
         case bump
@@ -56,6 +57,21 @@ module Bump
       end
 
       private
+
+      def sanitize_options!(options)
+        options.each do |key, value|
+          options[key] = eval_true_false_and_nil(value)
+        end
+        options.delete_if{|key, value| value.nil?}
+      end
+
+      def eval_true_false_and_nil(value)
+        if ["true", "false", "nil"].include? value
+          eval(value)
+        else
+          value
+        end
+      end
 
       def bump(file, current, next_version, options)
         replace(file, current, next_version)

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -26,7 +26,7 @@ module Bump
       end
 
       def run(bump, options={})
-        sanitize_options!(options)
+        parse_cli_options!(options)
         options = defaults.merge(options)
 
         case bump
@@ -58,16 +58,21 @@ module Bump
 
       private
 
-      def sanitize_options!(options)
+      def parse_cli_options!(options)
         options.each do |key, value|
-          options[key] = eval_true_false_and_nil(value)
+          options[key] = parse_cli_options_value(value)
         end
         options.delete_if{|key, value| value.nil?}
       end
 
-      def eval_true_false_and_nil(value)
-        if ["true", "false", "nil"].include? value
-          eval(value)
+      def parse_cli_options_value(value)
+        case value
+        when "true"
+          true
+        when "false"
+          false
+        when "nil"
+          nil
         else
           value
         end

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -67,12 +67,9 @@ module Bump
 
       def parse_cli_options_value(value)
         case value
-        when "true"
-          true
-        when "false"
-          false
-        when "nil"
-          nil
+        when "true" then true
+        when "false" then false
+        when "nil" then nil
         else
           value
         end

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -22,7 +22,7 @@ namespace :bump do
         commit: ENV['COMMIT'],
         bundle: ENV['BUNDLE']
       }
-      run_bump.call(bump, options)
+      run_bump.call(bump, Bump::Bump.parse_cli_options!(options))
     end
   end
 

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -14,7 +14,7 @@ namespace :bump do
       desc "Bump #{bump} part of gem version"
     end
 
-    task bump, :tag do |_task, args|
+    task bump, Bump::Bump.defaults.keys do |_task, args|
       run_bump.call(bump, args)
     end
   end

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -15,6 +15,11 @@ namespace :bump do
     end
 
     task bump, Bump::Bump.defaults.keys do |_task, args|
+      args = {
+        tag: ENV['TAG'],
+        commit: ENV['COMMIT'],
+        bundle: ENV['BUNDLE']
+      }.merge(args)
       run_bump.call(bump, args)
     end
   end

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -14,13 +14,15 @@ namespace :bump do
       desc "Bump #{bump} part of gem version"
     end
 
-    task bump, Bump::Bump.defaults.keys do |_task, args|
-      args = {
+    task bump, :tag do |_task, args|
+      raise RakeArgumentsDeprecatedError,
+        "rake arguments are deprecated, use TAG=false to disable tagging" if args.tag
+      options = {
         tag: ENV['TAG'],
         commit: ENV['COMMIT'],
         bundle: ENV['BUNDLE']
-      }.merge(args)
-      run_bump.call(bump, args)
+      }
+      run_bump.call(bump, options)
     end
   end
 

--- a/spec/bump/tasks_spec.rb
+++ b/spec/bump/tasks_spec.rb
@@ -19,8 +19,12 @@ describe "rake bump" do
   end
 
   it "bumps a version and can optionally tag it" do
-    run "rake bump:patch[true]"
+    run "rake bump:patch TAG=true"
     `git tag`.split("\n").last.should == "v1.2.4"
+  end
+
+  it "fails with rake arguments" do
+    run "rake bump:patch[true]", :fail => true
   end
 
   it "honors the tag setting in Bump::Bump.defaults" do

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -22,7 +22,10 @@ describe Bump do
   it "should fail with multiple gemspecs" do
     write_gemspec
     write("xxxx.gemspec", "Gem::Specification.new{}")
-    bump("current", :fail => true).should == "More than one version file found (fixture.gemspec, xxxx.gemspec)\n"
+    result = bump("current", :fail => true)
+    result.should include "More than one version file found"
+    result.should include "fixture.gemspec"
+    result.should include "xxxx.gemspec"
   end
 
   it "should fail if version is weird" do

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -379,6 +379,21 @@ describe Bump do
     end
   end
 
+  context ".parse_cli_options!" do
+    it "returns the evaluated values of passed hash options" do
+      Bump::Bump.parse_cli_options!({tag: 'nil'})
+        .should == {}
+
+      Bump::Bump.parse_cli_options!({commit: 'true', bundle: 'false'})
+        .should == {commit: true, bundle: false}
+
+      options = {tag: 'nil', commit: 'true', bundle: 'false'}
+      expected_return = {commit: true, bundle: false}
+      Bump::Bump.parse_cli_options!(options).should == expected_return
+      options.should == expected_return
+    end
+  end
+
   context "VERSION in lib file" do
     let(:version_file) { "lib/foo.rb" }
 


### PR DESCRIPTION
Update `rake bump:<bump_type>` to accept commit and bundle options.

Bump::Bump.defaults keys are updated to respect `rake bump:patch[<some_tag>]` current behavior.

Example of how to pass commit and bundle options.
`rake bump:<bump_type>[<tag>, <commit>, <bundle>]`

To Do:

[ ] Add tests
[ ] Update Readme