### PR TITLE
changelog support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,6 @@ Style/SymbolArray:
 
 Layout/LineLength:
   Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ or
 
     bump patch -m "Something extra"
 
+### `--changelog`
+
+Update `CHANGELOG.md` when bumping.
+This requires a heading (starting with `##`) that includes the previous version and a heading above that, for example:
+
+```markdown
+### Next
+- Added bar
+
+### v0.0.0 - 2019-12-24
+- Added foo
+```
+
 ## Rake
 
 ```ruby
@@ -90,7 +103,9 @@ require "bump/tasks"
 #
 # bump the version in additional files
 # Bump.replace_in_default = ["Readme.md"]
-
+#
+# Maintain changelog:
+# Bump.changelog = true
 ```
 
     rake bump:current                           # display current version

--- a/bin/bump
+++ b/bin/bump
@@ -27,6 +27,7 @@ OptionParser.new do |opts|
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("--tag-prefix TAG_PREFIX", "Prefix the tag with this string, ex. 'v'") { |tag_prefix| options[:tag_prefix] = tag_prefix }
   opts.on("--replace-in FILE", String, "Replace old version with the new version additionally in this file") { |f| (options[:replace_in] ||= []) << f }
+  opts.on("--changelog", "Update CHANGELOG.md") { options[:changelog] = true }
   opts.on("-h", "--help", "Show this.") { puts opts; exit }
 end.parse!
 


### PR DESCRIPTION
Given the user has a CHANGELOG.md and opts in to changelog management, a bump will change:

```
## Next
 - foo

## v1.0.0 - 2019-12-24
- bar
```

into

```
## Next

## v1.0.1 - 2019-12-26
 - foo

## v1.0.0 - 2019-11-24
- bar
```

@gregorym @vanchi-zendesk