### PR TITLE
Improve changelog message, mention :editor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ require "bump/tasks"
 #
 # Maintain changelog:
 # Bump.changelog = true
+# Opens the changelog in an editor when bumping
+# Bump.changelog = :editor
 ```
 
     rake bump:current                           # display current version

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -184,7 +184,7 @@ module Bump
       def bump_changelog(file, current)
         parts = File.read(file).split(/(^##+.*)/) # headlines and their content
         prev_index = parts.index { |p| p =~ /(^##+.*(\d+\.\d+\.\d+(\.[a-z]+)?).*)/ } # position of previous version
-        return "Unable to find previous version" unless prev_index
+        return "Unable to find previous version in CHANGELOG.md" unless prev_index
 
         # reuse the same style by just swapping the numbers
         new_heading = "\n" + parts[prev_index].sub($2, current)

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -653,7 +653,7 @@ describe Bump do
           Wut ?
         TEXT
         f.close
-        Bump::Bump.send(:bump_changelog, f.path, '1.3.0').should == "Unable to find previous version"
+        Bump::Bump.send(:bump_changelog, f.path, '1.3.0').should == "Unable to find previous version in CHANGELOG.md"
       end
     end
   end


### PR DESCRIPTION
Changelog feature is pretty cool :)

I was trying to use the new changelog feature by adding `Bump.changelog = :editor` to my Rakefile, and when trying to execute the rake task I got the message below:
```
$ bundle exec rake bump:patch
Unable to find previous version
```
I thought the issue was with the version.rb file, until I figured out it was related to CHANGELOG.md.

cc @grosser 