### PR TITLE
Bump changelog: improve output if `## Next` is not present

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -187,13 +187,18 @@ module Bump
         return "Unable to find previous version" unless prev_index
 
         # reuse the same style by just swapping the numbers
-        new_heading = "\n" + parts[prev_index].sub($2, current)
-
+        new_heading = parts[prev_index].sub($2, current)
         # add current date if previous heading used that
         new_heading.sub!(/\d\d\d\d-\d\d-\d\d/, Time.now.strftime('%Y-%m-%d'))
 
-        # put our new heading underneath the "Next" heading, which should be above the last version
-        parts.insert prev_index - 1, new_heading
+        if prev_index < 2
+          # previous version is first '##' element (no '## Next' present), add line feed after version to avoid
+          # '## v1.0.1## v1.0.0'
+          parts.insert prev_index - 1, new_heading + "\n"
+        else
+          # put our new heading underneath the "Next" heading, which should be above the last version
+          parts.insert prev_index - 1, "\n" + new_heading
+        end
 
         File.write file, parts.join("")
         nil

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -469,6 +469,23 @@ describe Bump do
         bump("patch --edit-changelog").should include("edit CHANGELOG.md\n[master")
       end
     end
+
+    context "Changelog without ## Next" do
+      before do
+        write_gemspec('"1.0.0"')
+        write "CHANGELOG.md", <<-FILE.gsub(/^\s+/, "")
+          ## v1.0.0
+          - bar
+        FILE
+        `git add CHANGELOG.md #{gemspec}`
+      end
+
+      it "updates changelog" do
+        bump("patch --changelog")
+        read("CHANGELOG.md").should start_with "## v1.0.1\n## v1.0.0"
+        `git status`.should include "nothing to commit"
+      end
+    end
   end
 
   context ".current" do


### PR DESCRIPTION
CHANGELOG.md with `## Next`
```md
## Next

Foo.

## 0.1.0 - 2020-03-12

Initial version.

```

Executing `bump patch --changelog`:
```md
## Next
## 0.1.1 - 2020-03-14

Foo.

## 0.1.0 - 2020-03-12

Initial version.

```

CHANGELOG.md without `## Next`
```md
## 0.1.0 - 2020-03-12

Initial version.
```

Executing `bump patch --changelog`:
```md

## 0.1.1 - 2020-03-14## 0.1.0 - 2020-03-12

Initial version.

```

cc @grosser 