### PR TITLE
Add optional Bundler.with_unbundled_env call

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -164,7 +164,11 @@ module Bump
 
       def bundler_with_clean_env(&block)
         if defined?(Bundler)
-          Bundler.with_clean_env(&block)
+          if Bundler.respond_to?(:with_unbundled_env)
+            Bundler.with_unbundled_env(&block)
+          else
+            Bundler.with_clean_env(&block)
+          end
         else
           yield
         end

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -403,7 +403,7 @@ describe Bump do
         gemspec
       RUBY
       `git add Gemfile #{gemspec}`
-      Bundler.with_clean_env { run("bundle") }
+      bundler_with_clean_env { run("bundle") }
       `git add Gemfile.lock`
     end
 
@@ -707,5 +707,13 @@ describe Bump do
     yield
   ensure
     File.unlink file
+  end
+
+  def bundler_with_clean_env(&block)
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env(&block)
+    else
+      Bundler.with_clean_env(&block)
+    end
   end
 end


### PR DESCRIPTION
As with_clean_env has been deprecated in favor of `Bundler.with_unbundled_env`

To avoid showing [the warning message](https://github.com/rubygems/rubygems/commit/fb2c51c9661c07244ea3e7f02469969de772da99#diff-aaa92e25b0f70a4d5363ed7224253bd5R324) every time `bump` is ran

Fixes #105 