### PR TITLE
feat: support showing file and current without any descriptive text

### DIFF
--- a/bin/bump
+++ b/bin/bump
@@ -29,6 +29,7 @@ OptionParser.new do |opts|
   opts.on("--replace-in FILE", String, "Replace old version with the new version additionally in this file") { |f| (options[:replace_in] ||= []) << f }
   opts.on("--changelog", "Update CHANGELOG.md") { options[:changelog] = true }
   opts.on("--edit-changelog", "Use $EDITOR to open changelog before committing, e.g. 'subl -n -w' or 'nano'.") { options[:changelog] = :editor }
+  opts.on("--value-only", "Do not prefix the output with any descriptive text") { options[:value_only] = true }
   opts.on("-h", "--help", "Show this.") { puts opts; exit }
 end.parse!
 

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -43,14 +43,14 @@ module Bump
 
           bump_set(options[:version], options)
         when "current"
-          ["Current version: #{current}", 0]
+          [options[:value_only] ? current : "Current version: #{current}", 0]
         when "show-next"
           increment = options[:increment]
           raise InvalidIncrementError unless BUMPS.include?(increment)
 
           [next_version(increment), 0]
         when "file"
-          ["Version file path: #{file}", 0]
+          [options[:value_only] ? file : "Version file path: #{file}", 0]
         else
           raise InvalidOptionError
         end
@@ -154,7 +154,7 @@ module Bump
         commit next_version, options if options[:commit]
 
         # tell user the result
-        ["Bump version #{current} to #{next_version}", 0]
+        [options[:value_only] ? next_version : "Bump version #{current} to #{next_version}", 0]
       end
 
       def open_changelog(log)

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -199,6 +199,18 @@ describe Bump do
       end
     end
 
+    context "when value_only is not specified" do
+      it "includes descriptive text" do
+        bump("current").should include("Current version:")
+      end
+    end
+
+    context "when value_only is specified" do
+      it "only returns the version" do
+        bump("current --value-only").should eq("4.2.3\n")
+      end
+    end
+
     it "fails when asked to bump in missing additional files" do
       bump("patch --replace-in Readme.md", fail: true)
     end
@@ -240,7 +252,14 @@ describe Bump do
     end
 
     it "show file path" do
-      bump("file").should include(version_file)
+      output = bump("file")
+      output.should include(version_file)
+      output.should include("Version file path:")
+      read(version_file).should include("VERSION = ")
+    end
+
+    it "show file path with --value-only" do
+      bump("file --value-only").should eq(version_file + "\n")
       read(version_file).should include("VERSION = ")
     end
 


### PR DESCRIPTION
Thanks for the bump gem. I have been using it in automated releases for years. 

I recently created a github action to release the (many!) Ruby gems from within my OSS github organization, and I made a slight tweak to the bump CLI that I'd like to contribute back. See the usage here https://github.com/pact-foundation/release-gem/search?q=--value-only

It allows me to use the information on the command line without having to create a ruby script to call the underlying library directly.