### PR TITLE
Remove descriptive text from `current` and `file` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A gem to bump versions of gems and chef-cookbooks.
 
     bump current
 
-> Current version: 0.1.2
+> 0.1.2
 
 ### Bump (major, minor, patch, pre)
 
@@ -29,13 +29,13 @@ A gem to bump versions of gems and chef-cookbooks.
 
     bump show-next patch
 
-> Next patch version: 0.1.3
+> 0.1.3
 
 ### Show version file path
 
     bump file
 
-> Version file path: lib/foo/version.rb
+> lib/foo/version.rb
 
 ## Options
 
@@ -93,8 +93,8 @@ This requires a heading (starting with `##`) that includes the previous version 
 
 ### `--edit-changelog`
 
-Updates CHANGELOG.md when bumping (see above), and 
-opens the changelog in an editor specified in `$EDITOR` (or `vi`), 
+Updates CHANGELOG.md when bumping (see above), and
+opens the changelog in an editor specified in `$EDITOR` (or `vi`),
 then waits for the editor to be closed and continues.
 
 ```bash

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -43,14 +43,14 @@ module Bump
 
           bump_set(options[:version], options)
         when "current"
-          ["Current version: #{current}", 0]
+          [current, 0]
         when "show-next"
           increment = options[:increment]
           raise InvalidIncrementError unless BUMPS.include?(increment)
 
           [next_version(increment), 0]
         when "file"
-          ["Version file path: #{file}", 0]
+          [file, 0]
         else
           raise InvalidOptionError
         end

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -133,7 +133,7 @@ describe Bump do
     end
 
     it "should find current version" do
-      bump("current").should include("4.2.3")
+      bump("current").should eq("4.2.3\n")
       read(gemspec).should include('s.version = "4.2.3"')
     end
 
@@ -142,7 +142,7 @@ describe Bump do
     end
 
     it "should find version file" do
-      bump("file").should include("fixture.gemspec")
+      bump("file").should eq("fixture.gemspec\n")
     end
 
     it "should bump patch" do


### PR DESCRIPTION
So it can be used more cleanly by command line tools.