### PR TITLE
Re-enable git features when used in git submodule

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -33,7 +33,7 @@ module Bump
 
       def run(bump, options = {})
         options = defaults.merge(options)
-        options[:commit] = false unless File.directory?(".git")
+        options[:commit] = false unless File.exist?(".git")
 
         case bump
         when *BUMPS


### PR DESCRIPTION
This PR restores bump's git functionality when used for a gem that is configured as a submodule of another git repository. For example, a custom Rails engine inside a Rails application.

[Git 1.7.8 introduced changes](https://github.com/git/git/blob/2e71cbbddd64695d43383c25c7a054ac4ff86882/Documentation/RelNotes/1.7.8.txt#L109) to how it handles git submodules. In essence, `.git` inside the submodule is no longer a directory, but a file that contains a reference to the parent directory (gitfile mechanism). This causes `options[:commit] = false unless File.directory?(".git")` to disable git functionality.

Changing this to `File.exist?('.git')` still ensures that we're in a git repository, but also works for git submodules.