### PR TITLE
Add option to prefix commit messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .rspec
 bin/
 Gemfile.lock
+.tool-versions

--- a/bin/bump
+++ b/bin/bump
@@ -22,8 +22,8 @@ OptionParser.new do |opts|
     Options:
   BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
-  opts.on("-m", "--commit-message MSG", String, "Append MSG to the commit message.") { |msg| options[:commit_message] = msg }
-  opts.on("-p", "--commit-prefix PREFIX", String, "Commit message prefix default=TAG") { |msg| options[:commit_prefix] = msg }
+  opts.on("-m", "--commit-message MSG", String, "Append MSG to commit message eg. '<tag> commit message'") { |msg| options[:commit_message] = msg }
+  opts.on("-M", "--custom-commit-message MSG", String, "Custom commit message. Insert tag with {TAG}") { |msg| options[:custom_commit_message] = msg }
   opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("--tag-prefix TAG_PREFIX", "Prefix the tag with this string, ex. 'v'") { |tag_prefix| options[:tag_prefix] = tag_prefix }

--- a/bin/bump
+++ b/bin/bump
@@ -22,8 +22,7 @@ OptionParser.new do |opts|
     Options:
   BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
-  opts.on("-m", "--commit-message MSG", String, "Append MSG to commit message eg. '<tag> commit message'") { |msg| options[:commit_message] = msg }
-  opts.on("-M", "--custom-commit-message MSG", String, "Custom commit message. Insert tag with {TAG}") { |msg| options[:custom_commit_message] = msg }
+  opts.on("-m", "--commit-message MSG", String, "default: '<tag> MSG' or customize with %<tag> eg. 'chore: %<tag> bump version'") { |msg| options[:commit_message] = msg }
   opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("--tag-prefix TAG_PREFIX", "Prefix the tag with this string, ex. 'v'") { |tag_prefix| options[:tag_prefix] = tag_prefix }

--- a/bin/bump
+++ b/bin/bump
@@ -23,6 +23,7 @@ OptionParser.new do |opts|
   BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
   opts.on("-m", "--commit-message MSG", String, "Append MSG to the commit message.") { |msg| options[:commit_message] = msg }
+  opts.on("-p", "--commit-prefix COMMIT-PREFIX", String, "Commit message prefix default=TAG") { |msg| options[:commit_prefix] = msg }
   opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("--tag-prefix TAG_PREFIX", "Prefix the tag with this string, ex. 'v'") { |tag_prefix| options[:tag_prefix] = tag_prefix }

--- a/bin/bump
+++ b/bin/bump
@@ -23,7 +23,7 @@ OptionParser.new do |opts|
   BANNER
   opts.on("--no-commit", "Do not make a commit.") { options[:commit] = false }
   opts.on("-m", "--commit-message MSG", String, "Append MSG to the commit message.") { |msg| options[:commit_message] = msg }
-  opts.on("-p", "--commit-prefix COMMIT-PREFIX", String, "Commit message prefix default=TAG") { |msg| options[:commit_prefix] = msg }
+  opts.on("-p", "--commit-prefix PREFIX", String, "Commit message prefix default=TAG") { |msg| options[:commit_prefix] = msg }
   opts.on("--no-bundle", "Do not bundle.") { options[:bundle] = false }
   opts.on("--tag", "Create git tag from version (only if commit is true).") { options[:tag] = true }
   opts.on("--tag-prefix TAG_PREFIX", "Prefix the tag with this string, ex. 'v'") { |tag_prefix| options[:tag_prefix] = tag_prefix }

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -209,8 +209,8 @@ module Bump
       end
 
       def commit_message(version, options)
-        prefix = options[:commit_prefix] ? options[:commit_prefix] : "#{options[:tag_prefix]}#{version}"
-        options[:commit_message] ? "#{prefix} #{options[:commit_message]}" : tag
+        prefix = options[:commit_prefix] || "#{options[:tag_prefix]}#{version}"
+        options[:commit_message] ? "#{prefix} #{options[:commit_message]}" : prefix
       end
 
       def commit(version, options)

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -209,7 +209,7 @@ module Bump
       end
 
       def commit_message(version, options)
-        prefix = options[:commit_prefix] ? options[commit_prefix] : "#{options[:tag_prefix]}#{version}"
+        prefix = options[:commit_prefix] ? options[:commit_prefix] : "#{options[:tag_prefix]}#{version}"
         options[:commit_message] ? "#{prefix} #{options[:commit_message]}" : tag
       end
 

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -209,8 +209,15 @@ module Bump
       end
 
       def commit_message(version, options)
-        prefix = options[:commit_prefix] || "#{options[:tag_prefix]}#{version}"
-        options[:commit_message] ? "#{prefix} #{options[:commit_message]}" : prefix
+        tag = "#{options[:tag_prefix]}#{version}"
+
+        if options[:commit_message]
+          "#{tag} #{options[:commit_message]}"
+        elsif options[:custom_commit_message]
+          options[:custom_commit_message].gsub('{TAG}', tag)
+        else
+          tag
+        end
       end
 
       def commit(version, options)

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -212,8 +212,7 @@ module Bump
         tag = "#{options[:tag_prefix]}#{version}"
         return tag unless options[:commit_message]
 
-        commit_msg = options[:commit_message]
-        commit_msg.include?('%<tag>') ? commit_msg.gsub('%<tag>', tag) : "#{tag} #{commit_msg}"
+        options[:commit_message].dup.gsub!('%<tag>', tag) || "#{tag} #{commit_msg}"
       end
 
       def commit(version, options)

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -209,8 +209,8 @@ module Bump
       end
 
       def commit_message(version, options)
-        tag = "#{options[:tag_prefix]}#{version}"
-        options[:commit_message] ? "#{tag} #{options[:commit_message]}" : tag
+        prefix = options[:commit_prefix] ? options[commit_prefix] : "#{options[:tag_prefix]}#{version}"
+        options[:commit_message] ? "#{prefix} #{options[:commit_message]}" : tag
       end
 
       def commit(version, options)

--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -210,14 +210,10 @@ module Bump
 
       def commit_message(version, options)
         tag = "#{options[:tag_prefix]}#{version}"
+        return tag unless options[:commit_message]
 
-        if options[:commit_message]
-          "#{tag} #{options[:commit_message]}"
-        elsif options[:custom_commit_message]
-          options[:custom_commit_message].gsub('{TAG}', tag)
-        else
-          tag
-        end
+        commit_msg = options[:commit_message]
+        commit_msg.include?('%<tag>') ? commit_msg.gsub('%<tag>', tag) : "#{tag} #{commit_msg}"
       end
 
       def commit(version, options)

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -29,7 +29,7 @@ namespace :bump do
         tag_prefix: ENV['TAG_PREFIX'],
         commit: ENV['COMMIT'],
         commit_message: ENV['COMMIT_MESSAGE'],
-        commit_prefix: ENV['COMMIT_PREFIX'],
+        custom_commit_message: ENV['CUSTOM_COMMIT_MESSAGE'],
         bundle: ENV['BUNDLE'],
         increment: ENV['INCREMENT']
       }

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -29,6 +29,7 @@ namespace :bump do
         tag_prefix: ENV['TAG_PREFIX'],
         commit: ENV['COMMIT'],
         commit_message: ENV['COMMIT_MESSAGE'],
+        commit_prefix: ENV['COMMIT_PREFIX'],
         bundle: ENV['BUNDLE'],
         increment: ENV['INCREMENT']
       }

--- a/lib/bump/tasks.rb
+++ b/lib/bump/tasks.rb
@@ -29,7 +29,6 @@ namespace :bump do
         tag_prefix: ENV['TAG_PREFIX'],
         commit: ENV['COMMIT'],
         commit_message: ENV['COMMIT_MESSAGE'],
-        custom_commit_message: ENV['CUSTOM_COMMIT_MESSAGE'],
         bundle: ENV['BUNDLE'],
         increment: ENV['INCREMENT']
       }

--- a/spec/bump/tasks_spec.rb
+++ b/spec/bump/tasks_spec.rb
@@ -61,11 +61,18 @@ describe "rake bump" do
     `git log -1 --pretty=format:'%s'`.should == "v1.3.0"
   end
 
-  it "appends custom commit message" do
+  it "appends commit message" do
     output = run "COMMIT_MESSAGE='release' rake bump:minor"
     output.should include("1.3.0")
     read("VERSION").should == "1.3.0\n"
     `git log -1 --pretty=format:'%s'`.should == "v1.3.0 release"
+  end
+
+  it "appends custom commit message" do
+    output = run "CUSTOM_COMMIT_MESSAGE='chore: {TAG} release' rake bump:minor"
+    output.should include("1.3.0")
+    read("VERSION").should == "1.3.0\n"
+    `git log -1 --pretty=format:'%s'`.should == "chore: v1.3.0 release"
   end
 
   it "fails when it cannot bump" do

--- a/spec/bump/tasks_spec.rb
+++ b/spec/bump/tasks_spec.rb
@@ -68,13 +68,6 @@ describe "rake bump" do
     `git log -1 --pretty=format:'%s'`.should == "v1.3.0 release"
   end
 
-  it "appends custom commit message" do
-    output = run "CUSTOM_COMMIT_MESSAGE='chore: {TAG} release' rake bump:minor"
-    output.should include("1.3.0")
-    read("VERSION").should == "1.3.0\n"
-    `git log -1 --pretty=format:'%s'`.should == "chore: v1.3.0 release"
-  end
-
   it "fails when it cannot bump" do
     write "VERSION", "AAA"
     run "rake bump:minor", fail: true

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -79,6 +79,26 @@ describe Bump do
       `git status`.should include "nothing to commit"
     end
 
+    it "should add commit prefix if --commit-prefix flag was given" do
+      write_gemspec
+      `git add #{gemspec}`
+
+      bump("patch --commit-prefix 'Commit prefix.'")
+
+      `git log -1 --pretty=format:'%s'`.should include "Commit prefix."
+      `git status`.should include "nothing to commit"
+    end
+
+    it "should add commit prefix if -p flag was given" do
+      write_gemspec
+      `git add #{gemspec}`
+
+      bump("patch -m 'Commit prefix.'")
+
+      `git log -1 --pretty=format:'%s'`.should include "Commit prefix."
+      `git status`.should include "nothing to commit"
+    end
+
     it "should not commit if --no-commit flag was given" do
       write_gemspec
       `git add #{gemspec}`

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -79,24 +79,13 @@ describe Bump do
       `git status`.should include "nothing to commit"
     end
 
-    it "should add commit prefix if --commit-prefix flag was given" do
+    it "should add tag to commit message if {TAG} placeholder was in message" do
       write_gemspec
       `git add #{gemspec}`
 
-      bump("patch --commit-prefix 'Commit prefix.'")
+      bump("patch -M 'Commit message. {TAG}'")
 
-      `git log -1 --pretty=format:'%s'`.should include "Commit prefix."
-      `git status`.should include "nothing to commit"
-    end
-
-    it "should add commit prefix if -p flag was given" do
-      write_gemspec
-      `git add #{gemspec}`
-
-      bump("patch -m 'Commit prefix.'")
-
-      `git log -1 --pretty=format:'%s'`.should include "Commit prefix."
-      `git status`.should include "nothing to commit"
+      `git log -1 --pretty=format:'%s'`.should include 'Commit message. v4.2.4'
     end
 
     it "should not commit if --no-commit flag was given" do

--- a/spec/bump_spec.rb
+++ b/spec/bump_spec.rb
@@ -79,11 +79,11 @@ describe Bump do
       `git status`.should include "nothing to commit"
     end
 
-    it "should add tag to commit message if {TAG} placeholder was in message" do
+    it "should add tag to commit message if %<tag> placeholder was in message" do
       write_gemspec
       `git add #{gemspec}`
 
-      bump("patch -M 'Commit message. {TAG}'")
+      bump("patch -m 'Commit message. %<tag>'")
 
       `git log -1 --pretty=format:'%s'`.should include 'Commit message. v4.2.4'
     end


### PR DESCRIPTION
### Description

Introduces the ability to prefix commit messages when using the `bump patch` command. This is particularly helpful in situations where conventional commits are used and the commit message or prefix is needed to classify the commit. It also helps `bump` play nicely with CHANGELOG.md generators. ie. [cocogitto](https://github.com/cocogitto/cocogitto)

### Implementation

- [x] Add a new option --commit-prefix to the `bump patch` command, allowing users to provide a custom prefix for the generated commit message.

``` shell
bump patch -p 'feat(SomeFeature)' -m 'Some commit message'
```
- [x] Modify the code to include the provided prefix in the commit message when the --commit-prefix option is used. Defaults to TAG, as currently implemented.

- [x] Add Tests
- [x] All green

I assumed this change was small enough to submit a PR directly, rather than starting with an issue, apologies if this is not cool. I'm more than happy to discuss any changes that may be needed in order to implement this feature effectively. Please feel free to provide feedback, and I'll be glad to work with you on refining the implementation.

Thank you for considering this contribution,I look forward to your thoughts and suggestions!