### PR TITLE
Change 'bundle' command to 'bundle install'

### DIFF
--- a/lib/bump.rb
+++ b/lib/bump.rb
@@ -131,7 +131,7 @@ module Bump
         # bundle if needed
         if options[:bundle] && Dir.glob('*.gemspec').any? && under_version_control?("Gemfile.lock")
           bundler_with_clean_env do
-            return ["Bundle error", 1] unless system("bundle")
+            return ["Bundle error", 1] unless system("bundle install")
 
             git_add "Gemfile.lock" if options[:commit]
           end


### PR DESCRIPTION
There's an implicit run of `bundle` which is deprecated now. `bundle install` should be used.

Maybe even `bundle install --quiet` for less noise.

```
bundle exec bump patch --tag -m 'bump 1234'
          In a future version of Bundler, running `bundle` without argument will no longer run `bundle install`.
          Instead, the `cli_help` command will be displayed. Please use `bundle install` explicitly for scripts like CI/CD.
          You can use the future behavior now with `bundle config set default_cli_command cli_help --global`,
          or you can continue to use the current behavior with `bundle config set default_cli_command install_or_cli_help --global`.
          This message will be removed after a default_cli_command value is set.
Fetching gem metadata from https://
Resolving dependencies...
Using x 1.2.3 (was 1.2.2) from gemspec at `.` and installing its executables
Bundle complete! 1234 Gemfile dependencies, 1234 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```